### PR TITLE
Adds in page load check

### DIFF
--- a/specs/homepage.spec.ts
+++ b/specs/homepage.spec.ts
@@ -3,6 +3,14 @@ import { home } from '../pages'
 describe('Homepage', () => {
     before('Load homepage', () => {
         browser.url('./')
+        browser.waitUntil(() => {
+            const state = browser.execute(() =>{
+                return document.readyState
+            })
+            return String(state) === 'complete'
+        }, {
+            timeoutMsg: 'Page was unable to load'
+        })
     })
 
     it('Verify Welcome Button', () => {


### PR DESCRIPTION
To handle verifying a page load I came across `document.readyState' which returns a 'complete' upon load. So this is rolled up into a `waitUntil` to make sure that it doesn't move on until `complete` is passed back. I may eventually wrap this into it's own custom command as it'd be good to have for every load of a url.