### PR TITLE
New test for filtering events, plus some framework adjustments

### DIFF
--- a/pages/events.ts
+++ b/pages/events.ts
@@ -1,71 +1,43 @@
 class events {
 
-    public get filterButton() {
-        return $('//button[@class="filter-toggle"]')
-    }
-
-    public get filterAllSports() {
-        return $('//button[@value="all"]')
-    }
-
-    public get filterCycling() {
-        return $('//button[@value="CYCLING"]')
-    }
-
-    public get filterRunning() {
-        return $('//button[@value="RUNNING"]')
-    }
-
-    public get allIntensities() {
-        return $('//button[@value="all"][text()="All Intensities"]')
-    }
-
-    public get intensityA() {
-        return $('//button[@value="1"][text()="A"]')
-    }
-
-    public get intensityB() {
-        return $('//button[@value="2"][text()="B"]')
-    }
-
-    public get intensityC() {
-        return $('//button[@value="3"][text()="C"]')
-    }
-
-    public get intensityD() {
-        return $('//button[@value="4"][text()="D"]')
-    }
-
-    public get intensityE() {
-        return $('//button[@value="5"][text()="E (Open)"]')
-    }
-
-    public get allTimes() {
-        return $('//button[@value="all"][text()="All Start Times"]')
-    }
-
-    public get morningTime() {
-        return $('//button[@value="morning"]')
-    }
-
-    public get afternoonTime() {
-        return $('//button[@value="afternoon"]')
-    }
-
-    public get eveningTime() {
-        return $('//button[@value="evening"]')
-    }
-
-    public get nightTime() {
-        return $('//button[@value="night"]')
-    }
-
-    public get applyFilter() {
-        return $('//button[@class="apply-button"]')
+    public get noEventsHeader() {
+        return $('//div[contains(text(),"No results")]')
     }
 
     public get eventTitleHeader() {
         return $('//div[@class="tab-listing"]')
+    }
+
+    public get allEventsTitles() {
+        return $$('//div[@class="tab-listing"]')
+    }
+
+    public get sportsType() {
+        return $('//span[@class="map-sport-type"]')
+    }
+
+    public get allSportsType() {
+        return $$('//span[@class="map-sport-type"]')
+    }
+
+    public get intensityA() {
+        return $$('//div[@data-label="1"][@class="group-label"]')
+    }
+
+    public get intensityB() {
+        return $$('//div[@data-label="2"][@class="group-label"]')
+    }
+
+    public get intensityC() {
+        return $$('//div[@data-label="3"][@class="group-label"]')
+    }
+
+    public get intensityD() {
+        return $$('//div[@data-label="4"][@class="group-label"]')
+    }
+
+    public get intensityE() {
+        return $$('//div[@data-label="5"][@class="group-label"]')
     }
 }
 

--- a/pages/filter.ts
+++ b/pages/filter.ts
@@ -1,0 +1,90 @@
+class filter {
+    public get filterButton() {
+        return $('//button[@class="filter-toggle"]')
+    }
+
+    public get filterAllSports() {
+        return $('//button[@value="all"]')
+    }
+
+    public get filterCycling() {
+        return $('//button[@value="CYCLING"]')
+    }
+
+    public get filterRunning() {
+        return $('//button[@value="RUNNING"]')
+    }
+
+    public get allIntensities() {
+        return $('//button[@value="all"][text()="All Intensities"]')
+    }
+
+    public get intensityA() {
+        return $('//button[@value="1"][text()="A"]')
+    }
+
+    public get intensityB() {
+        return $('//button[@value="2"][text()="B"]')
+    }
+
+    public get intensityC() {
+        return $('//button[@value="3"][text()="C"]')
+    }
+
+    public get intensityD() {
+        return $('//button[@value="4"][text()="D"]')
+    }
+
+    public get intensityE() {
+        return $('//button[@value="5"][text()="E (Open)"]')
+    }
+
+    public get allTimes() {
+        return $('//button[@value="all"][text()="All Start Times"]')
+    }
+
+    public get morningTime() {
+        return $('//button[@value="morning"]')
+    }
+
+    public get afternoonTime() {
+        return $('//button[@value="afternoon"]')
+    }
+
+    public get eveningTime() {
+        return $('//button[@value="evening"]')
+    }
+
+    public get nightTime() {
+        return $('//button[@value="night"]')
+    }
+
+    public get applyFilter() {
+        return $('//button[@class="apply-button"]')
+    }
+
+    public get resetFilter() {
+        return $('//button[@class="reset-button"]')
+    }
+
+    /**
+     * 
+     * @param type - A, B, C, D, E
+     */
+    public pickIntensity(type: string) {
+        switch(type) {
+            case 'A':
+                return this.intensityA.click()
+            case 'B':
+                return this.intensityB.click()
+            case 'C':
+                return this.intensityC.click()
+            case 'D':
+                return this.intensityD.click()
+            case 'E':
+                return this.intensityE.click()
+        }
+    }
+}
+
+export default new filter()

--- a/pages/home.ts
+++ b/pages/home.ts
@@ -8,6 +8,16 @@ class home {
         return $('//a[@href="/create_account"]')
     }
 
+    public get cookieConsent() {
+        return $('#truste-consent-button')
+    }
+
+    public checkForCookieConsent() {
+        if (this.cookieConsent.isDisplayed()) {
+            this.cookieConsent.click()
+        }
+    }
+
 }
 
 export default new home()

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -1,9 +1,11 @@
 import home from './home'
 import menu from './menu'
 import events from './events'
+import filter from './filter'
 
 export {
     home,
     menu,
-    events
+    events,
+    filter
 }

--- a/pages/menu.ts
+++ b/pages/menu.ts
@@ -7,6 +7,10 @@ class menu {
     public get events() {
         return $('//a[@href="/events"]')
     }
+
+    public get support() {
+        return $('//a[@href="https://support.zwift.com/"]')
+    }
 }
 
 export default new menu()

--- a/specs/events.spec.ts
+++ b/specs/events.spec.ts
@@ -1,0 +1,37 @@
+import { events, home, menu, filter } from '../pages'
+
+describe('Events', () => {
+    before('Load events page', () => {
+        browser.url('./')
+        home.checkForCookieConsent()
+        menu.events.click()
+        browser.waitUntil(() => {
+            const state = browser.execute(() =>{
+                return document.readyState
+            })
+            return String(state) === 'complete'
+        }, {
+            timeoutMsg: 'Page was unable to load'
+        })
+    })
+
+    describe('Filter', () => {
+        it('Perform filter', () => {
+            const initialEvents = events.allEventsTitles.length
+            let filteredEvents: any;
+            filter.filterButton.click()
+            filter.resetFilter.click()
+            filter.filterRunning.click()
+            filter.eveningTime.click()
+            filter.pickIntensity('C')
+            filter.applyFilter.click()
+            browser.debug()
+            if(events.noEventsHeader.isDisplayed()) {
+                filteredEvents = 0
+            } else {
+                filteredEvents = events.allEventsTitles.length
+            }
+            expect(filteredEvents).toBeLessThan(initialEvents)
+        })
+    })
+})

--- a/specs/homepage.spec.ts
+++ b/specs/homepage.spec.ts
@@ -3,6 +3,7 @@ import { home } from '../pages'
 describe('Homepage', () => {
     before('Load homepage', () => {
         browser.url('./')
+        home.checkForCookieConsent()
         browser.waitUntil(() => {
             const state = browser.execute(() =>{
                 return document.readyState

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "removeComments": true,
         "noImplicitAny": false,
         "baseUrl": ".",
-        "types": ["node", "webdriverio", "@wdio/sync", "expect-webdriverio", "mocha"]
+        "types": ["node", "@wdio/sync", "expect-webdriverio", "mocha"]
     },
     "paths": {
         "*": [ "./*" ],

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -53,7 +53,10 @@ exports.config = {
         maxInstances: 5,
         //
         browserName: 'chrome',
-        acceptInsecureCerts: true
+        'goog:chromeOptions': {
+            args: ['--window-size=1280,800'],
+        },
+        acceptInsecureCerts: true,
         // If outputDir is provided WebdriverIO can capture driver session logs
         // it is possible to configure which logTypes to include/exclude.
         // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs


### PR DESCRIPTION
A test for filtering events has been added. It does a check for "no results" and sets the array to be empty, if results are present it grabs the length of them all.

Also added in a check for the cookie consent bar as it can interfere with filtering events.

Set the browser size to ensure the top nav is present