### PR TITLE
Config files for suite

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+export const presets = [
+    ['@babel/preset-env', {
+        targets: {
+            node: 12
+        }
+    }]
+];

--- a/package.json
+++ b/package.json
@@ -4,16 +4,23 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test:chrome": "npx wdio wdio.chrome.js",
+    "test:firefox": "npx wdio wdio.firefox.js",
+    "test:headless": "npx wdio wdio.headless.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@babel/cli": "^7.12.8",
+    "@babel/core": "^7.12.9",
+    "@babel/preset-env": "^7.12.7",
+    "@babel/register": "^7.12.1",
     "@types/mocha": "^8.0.4",
     "@wdio/cli": "^6.10.5",
     "@wdio/local-runner": "^6.10.5",
     "@wdio/mocha-framework": "^6.10.4",
+    "@wdio/selenium-standalone-service": "^6.10.4",
     "@wdio/spec-reporter": "^6.8.1",
     "@wdio/sync": "^6.10.4",
     "chromedriver": "^87.0.1",

--- a/specs/events.spec.ts
+++ b/specs/events.spec.ts
@@ -25,7 +25,6 @@ describe('Events', () => {
             filter.eveningTime.click()
             filter.pickIntensity('C')
             filter.applyFilter.click()
-            browser.debug()
             if(events.noEventsHeader.isDisplayed()) {
                 filteredEvents = 0
             } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "module": "CommonJS",
-        "target": "es2018",
+        "target": "es2019",
+        "sourceMap": false,
         "moduleResolution": "node",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,

--- a/wdio.chrome.js
+++ b/wdio.chrome.js
@@ -1,0 +1,12 @@
+const merge = require('deepmerge')
+const wdioConf = require('./wdio.conf.js')
+
+exports.config = merge(wdioConf.config, {
+    capabilities: [{
+        browserName: 'chrome',
+        'goog:chromeOptions': {
+            args: ['--window-size=1280,800'],
+            },
+        }
+    ],
+}, { clone: false })

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,4 +1,4 @@
-exports.config = {
+module.exports.config = {
     //
     // ====================
     // Runner Configuration
@@ -19,6 +19,14 @@ exports.config = {
     specs: [
         './specs/**/*.ts'
     ],
+    suites: {
+        homepage: [
+            './specs/homepage.spec.ts'
+        ],
+        events: [
+            './specs/events.spec.ts'
+        ]
+    },
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'
@@ -45,23 +53,19 @@ exports.config = {
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
-    capabilities: [{
+    // capabilities: [{
     
         // maxInstances can get overwritten per capability. So if you have an in-house Selenium
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.
-        maxInstances: 5,
+       // maxInstances: 5,
         //
-        browserName: 'chrome',
-        'goog:chromeOptions': {
-            args: ['--window-size=1280,800'],
-        },
-        acceptInsecureCerts: true,
+        // acceptInsecureCerts: true,
         // If outputDir is provided WebdriverIO can capture driver session logs
         // it is possible to configure which logTypes to include/exclude.
         // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
         // excludeDriverLogs: ['bugreport', 'server'],
-    }],
+    // }],
     //
     // ===================
     // Test Configurations
@@ -109,7 +113,6 @@ exports.config = {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    services: ['chromedriver'],
     
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber
@@ -139,8 +142,7 @@ exports.config = {
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        // TypeScript setup
-        require: ['ts-node/register'],
+        require: ['@babel/register', 'ts-node/register'],
         ui: 'bdd',
         timeout: 60000
     },

--- a/wdio.firefox.js
+++ b/wdio.firefox.js
@@ -1,0 +1,10 @@
+const merge = require('deepmerge')
+const wdioConf = require('./wdio.conf.js')
+
+exports.config = merge(wdioConf.config, {
+    services: ['selenium-standalone'],
+    capabilities: [{
+        browserName: 'firefox',
+        }
+    ],
+}, { clone: false })

--- a/wdio.headless.js
+++ b/wdio.headless.js
@@ -1,0 +1,12 @@
+const merge = require('deepmerge')
+const wdioConf = require('./wdio.conf.js')
+
+exports.config = merge(wdioConf.config, {
+    capabilities: [{
+        browserName: 'chrome',
+        'goog:chromeOptions': {
+            args: ['--window-size=1280,800', '--headless', '--disable-gpu'],
+            },
+        }
+    ],
+}, { clone: false })


### PR DESCRIPTION
Created config files for running tests off the main file. This provides some additional flexibility without having to have redundancy across the files. A file for chrome, firefox, and headless-chrome are now available and accessible with `npm run test:[browser]`

Babel was also set up as part of this to proivde some additional coverage for compatibility with modules.

Removed an errant debug in the events test